### PR TITLE
Note that AMD is the default module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ module.exports = function (broccoli) {
   var cjsTree = filterES6Modules(pickFiles(tree, {
     srcDir: '/',
     destDir: '/cjs'
-  }));
+  }), {
+    moduleType: 'cjs'
+  });
 
   // and AMD
   var amdTree = filterES6Modules(pickFiles(tree, {
@@ -52,7 +54,7 @@ $ broccoli build output
 Options
 -------
 
-- `moduleType` - `amd` or `cjs`
+- `moduleType` - `amd` (default) or `cjs`
 - `anonymous` - for amd output, whether or not to name your modules.
 - `packageName` - for named-amd output, prepends `packageName/` to your
   module names


### PR DESCRIPTION
Also adds `cjs` option to example code. 

The cjs part of the example code confused me at first because the `moduleType` option wasn't specified and it isn't the default.
