### PR TITLE
Add `moduleGenerator` option to set the module name based on filePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ Options
 
 - `moduleType` - `amd` or `cjs`
 - `anonymous` - for amd output, whether or not to name your modules.
-- `packageName` - for named-amd output, prepends `packageName/` to your
+- `moduleGenerator` - for amd output, function to provide the module name based on file path paramater
+- `packageName` - for named-amd output when `moduleGenerator` is not
+  present, prepends `packageName/` to your
   module names
-- `main` - for named-amd output, which file is the main entry point of
+- `main` - for named-amd output when `moduleGenerator` is not
+  present, which file is the main entry point of
   your module that will be returned with `require(['your-package'])`
 - every other option supported by the [transpiler][transpiler]
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ Filter.prototype.defaults = {
   anonymous: true,
   moduleType: 'amd',
   packageName: null,
-  main: null
+  main: null,
+  moduleGenerator: null
 };
 
 Filter.prototype.extensions = ['js']
@@ -27,7 +28,7 @@ Filter.prototype.targetExtension = 'js'
 
 Filter.prototype.setOptions = function(options) {
   var merged = extend({}, this.defaults, options);
-  this.options = rip(merged, ['moduleType', 'packageName', 'main']);
+  this.options = rip(merged, ['moduleType', 'packageName', 'main', 'moduleGenerator']);
   this.compilerOptions = merged;
   this.validateOptions();
 }
@@ -36,9 +37,10 @@ Filter.prototype.validateOptions = function() {
   if (
     this.options.moduleType == 'amd' &&
     this.compilerOptions.anonymous === false &&
-    !this.options.packageName
+    !this.options.packageName && 
+    !this.options.moduleGenerator
   ) {
-    throw new Error('You must specify a `packageName` option when using the `anonymous: false` option');
+    throw new Error('You must specify a `packageName` or `moduleGenerator` option when using the `anonymous: false` option');
   }
 }
 
@@ -51,10 +53,20 @@ Filter.prototype.getName = function (filePath) {
   if (this.compilerOptions.anonymous) {
     return null;
   }
-  var name = filePath.replace(/.js$/, '');
-  var main = this.options.main;
-  var packageName = this.options.packageName;
-  return name === main ? packageName : packageName+'/'+name;
+
+  var generator = this.options.moduleGenerator; 
+  if ( generator ) { 
+
+    return generator(filePath);
+
+  } else {
+
+    var name = filePath.replace(/.js$/, '');
+    var main = this.options.main;
+    var packageName = this.options.packageName;
+
+    return name === main ? packageName : packageName+'/'+name;
+  }
 };
 
 Filter.prototype.processString = function (fileContents, filePath) {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -9,17 +9,22 @@ describe('broccoli-es6-module-filter', function() {
     });
 
     it('separates compiler options from filter options', function() {
+
+      var moduleGenerator = function(filePath) {};
+
       var filter = new Filter(['lib'], {
         moduleType: 'amd',
         anonymous: false,
         packageName: 'test',
         main: 'main',
+        moduleGenerator: moduleGenerator,
         compatFix: true
       });
       assert.deepEqual(filter.options, {
         moduleType: 'amd',
         packageName: 'test',
-        main: 'main'
+        main: 'main',
+        moduleGenerator: moduleGenerator
       });
       assert.deepEqual(filter.compilerOptions, {
         anonymous: false,
@@ -27,7 +32,11 @@ describe('broccoli-es6-module-filter', function() {
       });
     });
 
-    it('complains if anonymous:false and no packageName', function() {
+    it('complains if anonymous:false and neither packageName nor moduleGenerator', function() {
+
+      var f1 = new Filter(null, { anonymous: false, packageName: 'app' });
+      var f2 = new Filter(null, { anonymous: false, moduleGenerator: function(file) {} });
+
       assert.throws(function() {
         new Filter(null, { anonymous: false });
       }, Error);
@@ -60,6 +69,17 @@ describe('broccoli-es6-module-filter', function() {
           main: 'main'
         });
         assert.equal(filter.getName('main.js'), 'package-name');
+      });
+
+      it('is the result of the moduleGenerator function', function() {
+        var filter = new Filter(['lib'], {
+          moduleType: 'amd',
+          anonymous: false,
+          moduleGenerator: function(filePath) {
+            return filePath;  
+          }
+        }); 
+        assert.equal(filter.getName('foo/bar.js'), 'foo/bar.js');
       });
     });
   });


### PR DESCRIPTION
This pattern is broadly used in rake pipeline filters as the [minispade filter](https://github.com/wycats/rake-pipeline-web-filters/blob/master/lib/rake-pipeline-web-filters/minispade_filter.rb). 

It allows to use the filter with more different project structures or build process.

``` js
var es6Options = { moduleGenerator: function(filePath) {
                    return filePath.replace(tmpFolder+'/', '')
                                   .replace('lib/','')
                                   .replace(/.js$/, '')
                                   .replace(/\/main$/, '');
                  }, 
                  anonymous: false };

app = es6Filter(app, es6Options); 
```
